### PR TITLE
Add metrics endpoint and port for total, succeeded and failed counters

### DIFF
--- a/cmd/auditlog-forwarder/app/options/options.go
+++ b/cmd/auditlog-forwarder/app/options/options.go
@@ -88,6 +88,9 @@ func (o *Options) ApplyTo(server *Config) error {
 		return err
 	}
 
+	serverConfig := o.Config.Server
+	server.Serving.MetricsAddress = net.JoinHostPort(serverConfig.Address, strconv.FormatUint(uint64(serverConfig.MetricsPort), 10))
+
 	server.InjectAnnotations = o.Config.InjectAnnotations
 
 	outputs, err := outputfactory.NewFromConfigs(o.Config.Outputs)
@@ -152,6 +155,7 @@ type Config struct {
 
 // Serving contains the configuration for the auditlog forwarder.
 type Serving struct {
-	TLSConfig *tls.Config
-	Address   string
+	TLSConfig      *tls.Config
+	Address        string
+	MetricsAddress string
 }

--- a/example/auditlog-forwarder-config.yaml
+++ b/example/auditlog-forwarder-config.yaml
@@ -7,8 +7,9 @@ log:
 
 server:
   port: 10443
+  metricsPort: 8080
   address: ""
-  
+
   tls:
     certFile: "/etc/certs/tls.crt"
     keyFile: "/etc/certs/tls.key"

--- a/example/local-setup/charts/auditlog-forwarder/templates/configmap.yaml
+++ b/example/local-setup/charts/auditlog-forwarder/templates/configmap.yaml
@@ -11,19 +11,20 @@ data:
   config.yaml: |
     apiVersion: config.auditlog-forwarder.gardener.cloud/v1alpha1
     kind: AuditlogForwarder
-    
+
     log:
       level: {{ .Values.config.log.level }}
       format: {{ .Values.config.log.format }}
-    
+
     server:
       port: {{ .Values.config.server.port }}
+      metricsPort: {{ .Values.config.server.metricsPort }}
       address: {{ .Values.config.server.address }}
       tls:
         certFile: /tls/tls.crt
         keyFile: /tls/tls.key
         clientCAFile: /ca/ca.crt
-    
+
     outputs:
     - http:
         url: https://echo-server.kube-system.svc.cluster.local:443/audit
@@ -31,7 +32,7 @@ data:
           caFile: /ca/ca.crt
           certFile: /client-certs/client.crt
           keyFile: /client-certs/client.key
-    
+
     injectAnnotations:
       environment: local-kind
       deployment: auditlog-forwarder-test

--- a/example/local-setup/charts/auditlog-forwarder/templates/deployment.yaml
+++ b/example/local-setup/charts/auditlog-forwarder/templates/deployment.yaml
@@ -27,8 +27,11 @@ spec:
         args:
         - --config=/config/config.yaml
         ports:
-        - name: port
+        - name: https
           containerPort: {{ .Values.config.server.port }}
+          protocol: TCP
+        - name: metrics
+          containerPort: {{ .Values.config.server.metricsPort }}
           protocol: TCP
         volumeMounts:
         - name: tls

--- a/example/local-setup/charts/auditlog-forwarder/templates/service.yaml
+++ b/example/local-setup/charts/auditlog-forwarder/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
   ports:
   - port: 443
+    name: https
     protocol: TCP
     targetPort: {{ .Values.config.server.port }}
     nodePort: 30021
+  - port: 8080
+    name: metrics
+    protocol: TCP
+    targetPort: {{ .Values.config.server.metricsPort }}
+    nodePort: 30022

--- a/example/local-setup/charts/auditlog-forwarder/values.yaml
+++ b/example/local-setup/charts/auditlog-forwarder/values.yaml
@@ -33,4 +33,5 @@ config:
 
   server:
     port: 10443
+    metricsPort: 8080
     address: ""

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.1
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
 	k8s.io/apimachinery v0.34.1
@@ -52,8 +54,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pkg/apis/config/v1alpha1/defaults.go
+++ b/pkg/apis/config/v1alpha1/defaults.go
@@ -25,4 +25,7 @@ func SetDefaults_Server(obj *Server) {
 	if obj.Port == 0 {
 		obj.Port = 10443
 	}
+	if obj.MetricsPort == 0 {
+		obj.MetricsPort = 8080
+	}
 }

--- a/pkg/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/apis/config/v1alpha1/defaults_test.go
@@ -34,16 +34,24 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Server.Port).To(Equal(uint(10443)))
 		})
 
+		It("should default the server metrics port", func() {
+			SetDefaults_AuditlogForwarder(obj)
+
+			Expect(obj.Server.MetricsPort).To(Equal(uint(8080)))
+		})
+
 		It("should not override existing values", func() {
 			obj.Log.Level = LogLevelDebug
 			obj.Log.Format = LogFormatText
 			obj.Server.Port = 8080
+			obj.Server.MetricsPort = 9090
 
 			SetDefaults_AuditlogForwarder(obj)
 
 			Expect(obj.Log.Level).To(Equal(LogLevelDebug))
 			Expect(obj.Log.Format).To(Equal(LogFormatText))
 			Expect(obj.Server.Port).To(Equal(uint(8080)))
+			Expect(obj.Server.MetricsPort).To(Equal(uint(9090)))
 		})
 	})
 
@@ -94,12 +102,26 @@ var _ = Describe("Defaults", func() {
 			Expect(serverConfig.Port).To(Equal(uint(10443)))
 		})
 
+		It("should default the metrics port to 8080", func() {
+			SetDefaults_Server(serverConfig)
+
+			Expect(serverConfig.MetricsPort).To(Equal(uint(8080)))
+		})
+
 		It("should not override existing port value", func() {
 			serverConfig.Port = 8080
 
 			SetDefaults_Server(serverConfig)
 
 			Expect(serverConfig.Port).To(Equal(uint(8080)))
+		})
+
+		It("should not override existing metrics port value", func() {
+			serverConfig.MetricsPort = 8090
+
+			SetDefaults_Server(serverConfig)
+
+			Expect(serverConfig.MetricsPort).To(Equal(uint(8090)))
 		})
 
 		It("should not set defaults for address (should remain empty)", func() {

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -60,6 +60,9 @@ type Server struct {
 	Address string `json:"address,omitempty"`
 	// TLS contains the TLS configuration for the server.
 	TLS TLS `json:"tls"`
+	// MetricsPort is the port that the server will listen on for metrics.
+	// +optional
+	MetricsPort uint `json:"metricsPort,omitempty"`
 }
 
 // TLS defines the TLS configuration for the server.

--- a/pkg/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/apis/config/v1alpha1/validation/validation.go
@@ -66,6 +66,10 @@ func validateServer(serverConfig *configv1alpha1.Server, fldPath *field.Path) fi
 		allErrs = append(allErrs, field.Required(fldPath.Child("port"), "port is required"))
 	}
 
+	if serverConfig.MetricsPort == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("metricsPort"), "metrics port is required"))
+	}
+
 	allErrs = append(allErrs, validateTLS(&serverConfig.TLS, fldPath.Child("tls"))...)
 
 	return allErrs

--- a/pkg/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/config/v1alpha1/validation/validation_test.go
@@ -26,7 +26,8 @@ var _ = Describe("#ValidateAuditlogForwarderConfiguration", func() {
 				Format: configv1alpha1.LogFormatJSON,
 			},
 			Server: configv1alpha1.Server{
-				Port: 10443,
+				Port:        10443,
+				MetricsPort: 8080,
 				TLS: configv1alpha1.TLS{
 					CertFile: "/path/to/cert.pem",
 					KeyFile:  "/path/to/key.pem",
@@ -62,6 +63,18 @@ var _ = Describe("#ValidateAuditlogForwarderConfiguration", func() {
 			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("server.port"),
+			}))))
+		})
+	})
+
+	Context("when server metrics port is missing", func() {
+		It("should return an error", func() {
+			config.Server.MetricsPort = 0
+
+			errs := ValidateAuditlogForwarder(config)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("server.metricsPort"),
 			}))))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:
This PR adds support for metrics on audit forwarding events. New serving port on 8080 is enabled on the `auditlog-forwarder` main container. Counters for total, succeeded and failed audit forwards added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```feature user
Metrics port enabled on the main container for newly introduces Prometheus counters: total, succeeded and failed audit event log forwards.
```
