### PR TITLE
Add hot-reload of TLS client credentials for HTTP outputs

### DIFF
--- a/cmd/auditlog-forwarder/app/app.go
+++ b/cmd/auditlog-forwarder/app/app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/auditlog-forwarder/cmd/auditlog-forwarder/app/options"
 	"github.com/gardener/auditlog-forwarder/internal/handler/audit"
+	"github.com/gardener/auditlog-forwarder/internal/output"
 	"github.com/gardener/auditlog-forwarder/internal/processor"
 	"github.com/gardener/auditlog-forwarder/internal/processor/annotation"
 	configv1alpha1 "github.com/gardener/auditlog-forwarder/pkg/apis/config/v1alpha1"
@@ -55,7 +56,7 @@ func NewCommand() *cobra.Command {
 			})
 
 			conf := &options.Config{}
-			if err := opt.ApplyTo(conf); err != nil {
+			if err := opt.ApplyTo(cmd.Context(), log, conf); err != nil {
 				return fmt.Errorf("cannot apply options: %w", err)
 			}
 
@@ -131,11 +132,24 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 		ch <- runServer(srvMetricsCtx, log, "metrics-server", false, srvMetrics, nil)
 	}(srvMetricsCh)
 
+	defer closeOutputs(log, conf.OutputsGuaranteed, conf.OutputsBestEffort)
+
 	select {
 	case err := <-srvMetricsCh:
 		return errors.Join(err, <-srvAuditCh)
 	case err := <-srvAuditCh:
 		return errors.Join(err, <-srvMetricsCh)
+	}
+}
+
+// closeOutputs closes all provided outputs, logging any errors.
+func closeOutputs(log logr.Logger, outputGroups ...[]output.Output) {
+	for _, outputs := range outputGroups {
+		for _, o := range outputs {
+			if err := o.Close(); err != nil {
+				log.Error(err, "Failed to close output", "output", o.Name())
+			}
+		}
 	}
 }
 

--- a/cmd/auditlog-forwarder/app/options/options.go
+++ b/cmd/auditlog-forwarder/app/options/options.go
@@ -119,7 +119,15 @@ func (o *Options) ApplyTo(ctx context.Context, log logr.Logger, server *Config) 
 		outputhttp.WithLogger(log.WithName("output")),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create BestEffort outputs: %w", err)
+		// Guaranteed outputs already succeeded and might be holding resources;
+		// close them so they don't leak now that we're returning an error and the caller will not.
+		var closeErrs []error
+		for _, out := range guaranteedOutputs {
+			if cerr := out.Close(); cerr != nil {
+				closeErrs = append(closeErrs, fmt.Errorf("failed to close guaranteed output %q: %w", out.Name(), cerr))
+			}
+		}
+		return errors.Join(fmt.Errorf("failed to create BestEffort outputs: %w", err), errors.Join(closeErrs...))
 	}
 	server.OutputsGuaranteed = guaranteedOutputs
 	server.OutputsBestEffort = bestEffortOutputs

--- a/cmd/auditlog-forwarder/app/options/options.go
+++ b/cmd/auditlog-forwarder/app/options/options.go
@@ -5,6 +5,7 @@
 package options
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -85,7 +87,7 @@ func (o *Options) LogConfig() (string, string) {
 }
 
 // ApplyTo applies the options to the config.
-func (o *Options) ApplyTo(server *Config) error {
+func (o *Options) ApplyTo(ctx context.Context, log logr.Logger, server *Config) error {
 	if err := o.applyServerConfigToServing(&server.Serving); err != nil {
 		return err
 	}
@@ -96,8 +98,10 @@ func (o *Options) ApplyTo(server *Config) error {
 	server.InjectAnnotations = o.Config.InjectAnnotations
 
 	guaranteedOutputs, err := outputfactory.NewHTTPOutputsWithOptions(
+		ctx,
 		o.Config.Outputs,
 		configv1alpha1.DeliveryModeGuaranteed,
+		outputhttp.WithLogger(log.WithName("output")),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create Guaranteed outputs: %w", err)
@@ -106,11 +110,13 @@ func (o *Options) ApplyTo(server *Config) error {
 	// Purposefully use different backoff settings for BestEffort outputs
 	// in order to give more time to the target system to receive the events in case of transient errors.
 	bestEffortOutputs, err := outputfactory.NewHTTPOutputsWithOptions(
+		ctx,
 		o.Config.Outputs,
 		configv1alpha1.DeliveryModeBestEffort,
 		outputhttp.WithMaxSendAttempts(6),
 		outputhttp.WithBaseBackoff(1*time.Second),
 		outputhttp.WithMaxBackoff(6*time.Second),
+		outputhttp.WithLogger(log.WithName("output")),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create BestEffort outputs: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 tool github.com/gardener/gardener/hack
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.31.0
@@ -31,7 +32,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/color v1.19.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gardener/gardener v1.145.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect

--- a/internal/handler/audit/handler_test.go
+++ b/internal/handler/audit/handler_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Handler", func() {
 		}
 
 		var err error
-		outputInsts, err = outputfactory.NewHTTPOutputsWithOptions(outputConfigs, configv1alpha1.DeliveryModeGuaranteed)
+		outputInsts, err = outputfactory.NewHTTPOutputsWithOptions(context.Background(), outputConfigs, configv1alpha1.DeliveryModeGuaranteed)
 		Expect(err).NotTo(HaveOccurred())
 
 		// reinitialize metrics before each test
@@ -305,7 +305,7 @@ var _ = Describe("Handler", func() {
 			}
 
 			var err error
-			bestEffortOutputs, err := outputfactory.NewHTTPOutputsWithOptions(outputConfigs, configv1alpha1.DeliveryModeBestEffort)
+			bestEffortOutputs, err := outputfactory.NewHTTPOutputsWithOptions(context.Background(), outputConfigs, configv1alpha1.DeliveryModeBestEffort)
 			Expect(err).NotTo(HaveOccurred())
 
 			handler, err = NewHandler(logger, processors, outputInsts, bestEffortOutputs)
@@ -358,7 +358,7 @@ var _ = Describe("Handler", func() {
 				},
 			}
 
-			slowOutputs, err := outputfactory.NewHTTPOutputsWithOptions(slowOutputConfigs, configv1alpha1.DeliveryModeBestEffort)
+			slowOutputs, err := outputfactory.NewHTTPOutputsWithOptions(context.Background(), slowOutputConfigs, configv1alpha1.DeliveryModeBestEffort)
 			Expect(err).NotTo(HaveOccurred())
 
 			handler, err = NewHandler(logger, processors, outputInsts, slowOutputs)

--- a/internal/output/factory/export_test.go
+++ b/internal/output/factory/export_test.go
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package http
+package factory
 
-var (
-	BackoffFunc = &backoffFunc
-	SleepFunc   = &sleepFunc
-)
+// CloseOutputs exposes the unexported closeOutputs helper for testing.
+var CloseOutputs = closeOutputs

--- a/internal/output/factory/factory.go
+++ b/internal/output/factory/factory.go
@@ -5,6 +5,7 @@
 package factory
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gardener/auditlog-forwarder/internal/output"
@@ -14,11 +15,11 @@ import (
 
 // NewHTTPOutputsWithOptions filters outputs by delivery mode and creates HTTP outputs with the given options.
 // It extracts only HTTP outputs matching the specified delivery mode and configures them with the provided options.
-func NewHTTPOutputsWithOptions(allOutputs []configv1alpha1.Output, deliveryMode configv1alpha1.DeliveryMode, httpOpts ...http.Option) ([]output.Output, error) {
+func NewHTTPOutputsWithOptions(ctx context.Context, allOutputs []configv1alpha1.Output, deliveryMode configv1alpha1.DeliveryMode, httpOpts ...http.Option) ([]output.Output, error) {
 	var outputs []output.Output
 	for _, outputConfig := range allOutputs {
 		if outputConfig.HTTP != nil && outputConfig.DeliveryMode == deliveryMode {
-			if httpOutput, err := http.New(outputConfig.HTTP, httpOpts...); err == nil {
+			if httpOutput, err := http.New(ctx, outputConfig.HTTP, httpOpts...); err == nil {
 				outputs = append(outputs, httpOutput)
 			} else {
 				return nil, fmt.Errorf("failed to create HTTP output: %w", err)

--- a/internal/output/factory/factory.go
+++ b/internal/output/factory/factory.go
@@ -6,6 +6,7 @@ package factory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gardener/auditlog-forwarder/internal/output"
@@ -19,13 +20,26 @@ func NewHTTPOutputsWithOptions(ctx context.Context, allOutputs []configv1alpha1.
 	var outputs []output.Output
 	for _, outputConfig := range allOutputs {
 		if outputConfig.HTTP != nil && outputConfig.DeliveryMode == deliveryMode {
-			if httpOutput, err := http.New(ctx, outputConfig.HTTP, httpOpts...); err == nil {
-				outputs = append(outputs, httpOutput)
-			} else {
-				return nil, fmt.Errorf("failed to create HTTP output: %w", err)
+			httpOutput, err := http.New(ctx, outputConfig.HTTP, httpOpts...)
+			if err != nil {
+				// Preserve the primary cause but surface any secondary damage from
+				// closing outputs we already built.
+				return nil, errors.Join(fmt.Errorf("failed to create HTTP output: %w", err), closeOutputs(outputs))
 			}
+			outputs = append(outputs, httpOutput)
 		}
 	}
 
 	return outputs, nil
+}
+
+// closeOutputs releases resources of the given outputs, joining any errors.
+func closeOutputs(outputs []output.Output) error {
+	var errs []error
+	for _, o := range outputs {
+		if err := o.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close output %q: %w", o.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/output/factory/factory_test.go
+++ b/internal/output/factory/factory_test.go
@@ -6,12 +6,24 @@ package factory_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/gardener/auditlog-forwarder/internal/output"
 	"github.com/gardener/auditlog-forwarder/internal/output/factory"
 	httpoutput "github.com/gardener/auditlog-forwarder/internal/output/http"
 	configv1alpha1 "github.com/gardener/auditlog-forwarder/pkg/apis/config/v1alpha1"
@@ -248,5 +260,123 @@ var _ = Describe("Output Factory", func() {
 			Expect(result[0].Name()).To(Equal(testServer.URL + "/http-1"))
 			Expect(result[1].Name()).To(Equal(testServer.URL + "/http-3"))
 		})
+
+		It("should close already-created outputs when a later one fails", func() {
+			// Write a valid CA file so the first output can be built (its TLS setup
+			// spawns a watcher goroutine); the second output references a nonexistent
+			// CA file and must fail, at which point the first output should be closed
+			// and its goroutine reaped rather than leaked.
+			tmpDir, err := os.MkdirTemp("", "factory-cleanup-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			caFile := filepath.Join(tmpDir, "ca.crt")
+			Expect(os.WriteFile(caFile, generateTestCAPEM(), 0600)).To(Succeed())
+
+			outputs := []configv1alpha1.Output{
+				{
+					DeliveryMode: configv1alpha1.DeliveryModeGuaranteed,
+					HTTP: &configv1alpha1.OutputHTTP{
+						URL: testServer.URL + "/ok",
+						TLS: &configv1alpha1.ClientTLS{CAFile: caFile},
+					},
+				},
+				{
+					DeliveryMode: configv1alpha1.DeliveryModeGuaranteed,
+					HTTP: &configv1alpha1.OutputHTTP{
+						URL: testServer.URL + "/broken",
+						TLS: &configv1alpha1.ClientTLS{CAFile: "/nonexistent/ca.pem"},
+					},
+				},
+			}
+
+			// Sample the baseline after any test-framework goroutines have settled.
+			Eventually(runtime.NumGoroutine).WithTimeout(500 * time.Millisecond).Should(BeNumerically(">", 0))
+			baseline := runtime.NumGoroutine()
+
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("failed to create HTTP output")))
+			Expect(result).To(BeNil())
+
+			// The first output's watcher goroutine must have been closed; the goroutine
+			// count should return to (approximately) baseline. Some slack is allowed
+			// for scheduler / GC goroutines that come and go around the test boundary.
+			Eventually(runtime.NumGoroutine).WithTimeout(2 * time.Second).WithPolling(20 * time.Millisecond).
+				Should(BeNumerically("<=", baseline+1),
+					"watcher goroutine of successfully-created output should have been closed on partial failure")
+		})
+	})
+
+	Describe("CloseOutputs", func() {
+		It("should return nil when all outputs close successfully", func() {
+			outputs := []output.Output{
+				&fakeOutput{name: "a"},
+				&fakeOutput{name: "b"},
+			}
+			Expect(factory.CloseOutputs(outputs)).To(Succeed())
+		})
+
+		It("should join errors from failing closes and continue closing the rest", func() {
+			errA := errors.New("boom-A")
+			errC := errors.New("boom-C")
+			outB := &fakeOutput{name: "b"}
+			outputs := []output.Output{
+				&fakeOutput{name: "a", closeErr: errA},
+				outB,
+				&fakeOutput{name: "c", closeErr: errC},
+			}
+
+			err := factory.CloseOutputs(outputs)
+			Expect(err).To(HaveOccurred())
+			// Both underlying errors must be wrapped in the joined result — this is
+			// what guarantees a leaking fsnotify handle (or similar) is not silently
+			// swallowed when NewHTTPOutputsWithOptions fails partway through.
+			Expect(errors.Is(err, errA)).To(BeTrue(), "joined error must wrap errA")
+			Expect(errors.Is(err, errC)).To(BeTrue(), "joined error must wrap errC")
+			Expect(err.Error()).To(ContainSubstring(`"a"`))
+			Expect(err.Error()).To(ContainSubstring(`"c"`))
+			// A single failing Close must NOT short-circuit the rest — every output
+			// still gets its Close call.
+			Expect(outB.closed).To(BeTrue(), "close of intermediate output must still happen")
+		})
 	})
 })
+
+// generateTestCAPEM returns a minimal self-signed CA in PEM form, suitable
+// for satisfying x509.CertPool.AppendCertsFromPEM in tests. Kept local to
+// this file so the factory package's test does not pull in the full cert
+// helpers from the http package's test file.
+func generateTestCAPEM() []byte {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "factory-test-ca"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	Expect(err).NotTo(HaveOccurred())
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// fakeOutput is a stub output.Output used to exercise closeOutputs' error
+// aggregation without spinning up real HTTP outputs.
+type fakeOutput struct {
+	name     string
+	closeErr error
+	closed   bool
+}
+
+func (f *fakeOutput) Send(_ context.Context, _ []byte) error { return nil }
+func (f *fakeOutput) Name() string                           { return f.name }
+func (f *fakeOutput) Close() error {
+	f.closed = true
+	return f.closeErr
+}

--- a/internal/output/factory/factory_test.go
+++ b/internal/output/factory/factory_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Output Factory", func() {
 			// The first output's watcher goroutine must have been closed; the goroutine
 			// count should return to (approximately) baseline. Some slack is allowed
 			// for scheduler / GC goroutines that come and go around the test boundary.
-			Eventually(runtime.NumGoroutine).WithTimeout(2 * time.Second).WithPolling(20 * time.Millisecond).
+			Eventually(runtime.NumGoroutine).WithTimeout(2*time.Second).WithPolling(20*time.Millisecond).
 				Should(BeNumerically("<=", baseline+1),
 					"watcher goroutine of successfully-created output should have been closed on partial failure")
 		})

--- a/internal/output/factory/factory_test.go
+++ b/internal/output/factory/factory_test.go
@@ -5,6 +5,7 @@
 package factory_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"time"
 
@@ -46,7 +47,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Name()).To(Equal(testServer.URL))
@@ -68,7 +69,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeBestEffort)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeBestEffort)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Name()).To(Equal(testServer.URL + "/best-effort"))
@@ -88,7 +89,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 		})
@@ -115,7 +116,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(HaveLen(2))
 			Expect(result[0].Name()).To(Equal(testServer.URL + "/guaranteed-1"))
@@ -132,7 +133,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeEmpty())
 		})
@@ -140,7 +141,7 @@ var _ = Describe("Output Factory", func() {
 		It("should handle empty outputs slice", func() {
 			outputs := []configv1alpha1.Output{}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeEmpty())
 		})
@@ -156,6 +157,7 @@ var _ = Describe("Output Factory", func() {
 			}
 
 			result, err := factory.NewHTTPOutputsWithOptions(
+				context.Background(),
 				outputs,
 				configv1alpha1.DeliveryModeGuaranteed,
 				httpoutput.WithMaxSendAttempts(10),
@@ -184,6 +186,7 @@ var _ = Describe("Output Factory", func() {
 			}
 
 			result, err := factory.NewHTTPOutputsWithOptions(
+				context.Background(),
 				outputs,
 				configv1alpha1.DeliveryModeGuaranteed,
 				httpoutput.WithMaxSendAttempts(5),
@@ -207,7 +210,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring("failed to create HTTP output")))
 			Expect(result).To(BeNil())
@@ -239,7 +242,7 @@ var _ = Describe("Output Factory", func() {
 				},
 			}
 
-			result, err := factory.NewHTTPOutputsWithOptions(outputs, configv1alpha1.DeliveryModeGuaranteed)
+			result, err := factory.NewHTTPOutputsWithOptions(context.Background(), outputs, configv1alpha1.DeliveryModeGuaranteed)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(HaveLen(2))
 			Expect(result[0].Name()).To(Equal(testServer.URL + "/http-1"))

--- a/internal/output/http/export_test.go
+++ b/internal/output/http/export_test.go
@@ -4,7 +4,25 @@
 
 package http
 
+import (
+	"time"
+
+	configv1alpha1 "github.com/gardener/auditlog-forwarder/pkg/apis/config/v1alpha1"
+)
+
 var (
 	BackoffFunc = backoffDuration
 	SleepFunc   = sleepWithContext
 )
+
+// SetTLSReloadDebounceForTest overrides the debounce duration for TLS reload and returns a cleanup function.
+func SetTLSReloadDebounceForTest(d time.Duration) func() {
+	old := tlsReloadDebounce
+	tlsReloadDebounce = d
+	return func() { tlsReloadDebounce = old }
+}
+
+// ReloadTLSClientForTest triggers a synchronous TLS client reload with the given config.
+func (o *Output) ReloadTLSClientForTest(tlsConfig *configv1alpha1.ClientTLS) {
+	o.reloadTLSClient(tlsConfig)
+}

--- a/internal/output/http/export_test.go
+++ b/internal/output/http/export_test.go
@@ -4,25 +4,7 @@
 
 package http
 
-import (
-	"time"
-
-	configv1alpha1 "github.com/gardener/auditlog-forwarder/pkg/apis/config/v1alpha1"
-)
-
 var (
 	BackoffFunc = backoffDuration
 	SleepFunc   = sleepWithContext
 )
-
-// SetTLSReloadDebounceForTest overrides the debounce duration for TLS reload and returns a cleanup function.
-func SetTLSReloadDebounceForTest(d time.Duration) func() {
-	old := tlsReloadDebounce
-	tlsReloadDebounce = d
-	return func() { tlsReloadDebounce = old }
-}
-
-// ReloadTLSClientForTest triggers a synchronous TLS client reload with the given config.
-func (o *Output) ReloadTLSClientForTest(tlsConfig *configv1alpha1.ClientTLS) {
-	o.reloadTLSClient(tlsConfig)
-}

--- a/internal/output/http/http.go
+++ b/internal/output/http/http.go
@@ -15,8 +15,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -33,22 +35,32 @@ const (
 	contentEncodingGzip   = "gzip"
 )
 
+// tlsReloadDebounce is the delay after a filesystem event before reloading TLS credentials.
+// Kubernetes secret updates produce multiple events in rapid succession; this coalesces them.
+var tlsReloadDebounce = 500 * time.Millisecond
+
 var _ output.Output = (*Output)(nil)
 
 // Output represents an HTTP output for forwarding audit events.
 type Output struct {
 	url    string
-	client *http.Client
+	client atomic.Pointer[http.Client]
 	// compression algorithm to use (currently only "gzip" or empty for none)
 	compression string
 
 	maxSendAttempts int
 	baseBackoff     time.Duration
 	maxBackoff      time.Duration
+
+	// logger is used for logging TLS reload events in the background watcher
+	logger logr.Logger
+	// watcher is the fsnotify watcher for TLS credential files (nil if TLS is not configured)
+	watcher *fsnotify.Watcher
 }
 
 // New creates a new HTTP output with the given configuration.
-func New(config *configv1alpha1.OutputHTTP, options ...Option) (*Output, error) {
+// The context controls the lifetime of the TLS credential file watcher.
+func New(ctx context.Context, config *configv1alpha1.OutputHTTP, options ...Option) (*Output, error) {
 	if config == nil {
 		return nil, fmt.Errorf("HTTP output configuration is nil")
 	}
@@ -58,22 +70,29 @@ func New(config *configv1alpha1.OutputHTTP, options ...Option) (*Output, error) 
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
-	output := &Output{
+	o := &Output{
 		url:             config.URL,
-		client:          client,
 		compression:     config.Compression,
 		maxSendAttempts: 4,
 		baseBackoff:     500 * time.Millisecond,
 		maxBackoff:      3 * time.Second,
+		logger:          logr.Discard(),
 	}
+	o.client.Store(client)
 
 	for _, opt := range options {
-		if err := opt(output); err != nil {
+		if err := opt(o); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
 
-	return output, nil
+	if config.TLS != nil {
+		if err := o.startTLSWatcher(ctx, config.TLS); err != nil {
+			return nil, fmt.Errorf("failed to start TLS file watcher: %w", err)
+		}
+	}
+
+	return o, nil
 }
 
 // Send sends data to the HTTP output.
@@ -111,7 +130,7 @@ func (o *Output) Send(ctx context.Context, data []byte) error {
 			req.Header.Set(headerContentEncoding, contentEncodingGzip)
 		}
 
-		resp, err := o.client.Do(req)
+		resp, err := o.client.Load().Do(req)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to send request: %w", err)
 		} else {
@@ -146,6 +165,107 @@ func (o *Output) Name() string {
 	return o.url
 }
 
+// Close stops the TLS file watcher and releases resources.
+func (o *Output) Close() error {
+	if o.watcher != nil {
+		return o.watcher.Close()
+	}
+	return nil
+}
+
+// startTLSWatcher begins watching the directories containing TLS credential files.
+// When files change, the HTTP client is rebuilt with freshly-loaded credentials.
+func (o *Output) startTLSWatcher(ctx context.Context, tlsConfig *configv1alpha1.ClientTLS) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	// Watch the parent directories of all configured TLS files.
+	// This handles Kubernetes secret mounts where files are symlinks that get atomically swapped.
+	dirs := tlsDirectories(tlsConfig)
+	for _, dir := range dirs {
+		if err := watcher.Add(dir); err != nil {
+			_ = watcher.Close()
+			return fmt.Errorf("failed to watch directory %s: %w", dir, err)
+		}
+	}
+
+	o.watcher = watcher
+
+	go o.watchTLSFiles(ctx, tlsConfig)
+	return nil
+}
+
+// watchTLSFiles is the event loop for the TLS file watcher.
+func (o *Output) watchTLSFiles(ctx context.Context, tlsConfig *configv1alpha1.ClientTLS) {
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case <-ctx.Done():
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return
+
+		case event, ok := <-o.watcher.Events:
+			if !ok {
+				return
+			}
+			// Only react to events that indicate file content changed
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Remove) {
+				continue
+			}
+
+			// Debounce: reset timer on each event
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(tlsReloadDebounce, func() {
+				o.reloadTLSClient(tlsConfig)
+			})
+
+		case _, ok := <-o.watcher.Errors:
+			if !ok {
+				return
+			}
+			// Watcher errors are non-fatal; continue watching
+		}
+	}
+}
+
+// reloadTLSClient rebuilds the HTTP client with freshly-loaded TLS credentials.
+// On failure, the existing client is kept.
+func (o *Output) reloadTLSClient(tlsConfig *configv1alpha1.ClientTLS) {
+	client, err := createHTTPClient(tlsConfig)
+	if err != nil {
+		o.logger.Error(err, "Failed to reload TLS credentials, keeping existing client")
+		return
+	}
+	o.client.Store(client)
+	o.logger.Info("Reloaded TLS credentials")
+}
+
+// tlsDirectories returns the unique parent directories of all configured TLS files.
+func tlsDirectories(tlsConfig *configv1alpha1.ClientTLS) []string {
+	seen := make(map[string]struct{})
+	var dirs []string
+
+	for _, file := range []string{tlsConfig.CAFile, tlsConfig.CertFile, tlsConfig.KeyFile} {
+		if file == "" {
+			continue
+		}
+		dir := filepath.Dir(file)
+		if _, ok := seen[dir]; !ok {
+			seen[dir] = struct{}{}
+			dirs = append(dirs, dir)
+		}
+	}
+
+	return dirs
+}
+
 // createHTTPClient creates an HTTP client with optional TLS configuration.
 func createHTTPClient(tlsConfig *configv1alpha1.ClientTLS) (*http.Client, error) {
 	client := &http.Client{
@@ -163,14 +283,9 @@ func createHTTPClient(tlsConfig *configv1alpha1.ClientTLS) (*http.Client, error)
 	}
 
 	if tlsConfig.CAFile != "" {
-		caCert, err := os.ReadFile(filepath.Clean(tlsConfig.CAFile))
+		caCertPool, err := loadCACertPool(tlsConfig.CAFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate file: %w", err)
-		}
-
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA certificate")
+			return nil, err
 		}
 		transport.TLSClientConfig.RootCAs = caCertPool
 	}
@@ -185,6 +300,20 @@ func createHTTPClient(tlsConfig *configv1alpha1.ClientTLS) (*http.Client, error)
 
 	client.Transport = transport
 	return client, nil
+}
+
+// loadCACertPool reads a PEM-encoded CA certificate file and returns a cert pool.
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	caCert, err := os.ReadFile(filepath.Clean(caFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate")
+	}
+	return caCertPool, nil
 }
 
 func isRetryableStatus(statusCode int) bool {

--- a/internal/output/http/http.go
+++ b/internal/output/http/http.go
@@ -33,11 +33,11 @@ const (
 
 	headerContentEncoding = "Content-Encoding"
 	contentEncodingGzip   = "gzip"
-)
 
-// tlsReloadDebounce is the delay after a filesystem event before reloading TLS credentials.
-// Kubernetes secret updates produce multiple events in rapid succession; this coalesces them.
-var tlsReloadDebounce = 500 * time.Millisecond
+	// defaultTLSReloadDebounce is the default delay after a filesystem event before reloading TLS credentials.
+	// Kubernetes secret updates produce multiple events in rapid succession; this coalesces them.
+	defaultTLSReloadDebounce = 500 * time.Millisecond
+)
 
 var _ output.Output = (*Output)(nil)
 
@@ -52,6 +52,8 @@ type Output struct {
 	baseBackoff     time.Duration
 	maxBackoff      time.Duration
 
+	// tlsReloadDebounce is the delay before reloading TLS credentials after a filesystem event
+	tlsReloadDebounce time.Duration
 	// logger is used for logging TLS reload events in the background watcher
 	logger logr.Logger
 	// watcher is the fsnotify watcher for TLS credential files (nil if TLS is not configured)
@@ -71,12 +73,13 @@ func New(ctx context.Context, config *configv1alpha1.OutputHTTP, options ...Opti
 	}
 
 	o := &Output{
-		url:             config.URL,
-		compression:     config.Compression,
-		maxSendAttempts: 4,
-		baseBackoff:     500 * time.Millisecond,
-		maxBackoff:      3 * time.Second,
-		logger:          logr.Discard(),
+		url:               config.URL,
+		compression:       config.Compression,
+		maxSendAttempts:   4,
+		baseBackoff:       500 * time.Millisecond,
+		maxBackoff:        3 * time.Second,
+		tlsReloadDebounce: defaultTLSReloadDebounce,
+		logger:            logr.Discard(),
 	}
 	o.client.Store(client)
 
@@ -165,12 +168,15 @@ func (o *Output) Name() string {
 	return o.url
 }
 
-// Close stops the TLS file watcher and releases resources.
+// Close triggers shutdown of the TLS file watcher goroutine and releases resources.
+// It is safe to call multiple times.
 func (o *Output) Close() error {
-	if o.watcher != nil {
-		return o.watcher.Close()
+	if o.watcher == nil {
+		return nil
 	}
-	return nil
+	err := o.watcher.Close()
+	o.watcher = nil
+	return err
 }
 
 // startTLSWatcher begins watching the directories containing TLS credential files.
@@ -222,15 +228,15 @@ func (o *Output) watchTLSFiles(ctx context.Context, tlsConfig *configv1alpha1.Cl
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
-			debounceTimer = time.AfterFunc(tlsReloadDebounce, func() {
+			debounceTimer = time.AfterFunc(o.tlsReloadDebounce, func() {
 				o.reloadTLSClient(tlsConfig)
 			})
 
-		case _, ok := <-o.watcher.Errors:
+		case err, ok := <-o.watcher.Errors:
 			if !ok {
 				return
 			}
-			// Watcher errors are non-fatal; continue watching
+			o.logger.Error(err, "File watcher error")
 		}
 	}
 }

--- a/internal/output/http/http.go
+++ b/internal/output/http/http.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,6 +42,15 @@ const (
 
 var _ output.Output = (*Output)(nil)
 
+// backoffFunc and sleepFunc are indirections over backoffDuration and
+// sleepWithContext used by Send()'s retry loop. They exist so tests can
+// substitute deterministic implementations via export_test.go; production
+// code must not reassign them. Send() is the only intended caller.
+var (
+	backoffFunc = backoffDuration
+	sleepFunc   = sleepWithContext
+)
+
 // Output represents an HTTP output for forwarding audit events.
 type Output struct {
 	url    string
@@ -54,10 +64,15 @@ type Output struct {
 
 	// tlsReloadDebounce is the delay before reloading TLS credentials after a filesystem event
 	tlsReloadDebounce time.Duration
-	// logger is used for logging TLS reload events in the background watcher
+	// logger is used by background operations of the HTTP output (currently the TLS file watcher).
 	logger logr.Logger
-	// watcher is the fsnotify watcher for TLS credential files (nil if TLS is not configured)
+	// watcher is the fsnotify watcher for TLS credential files (nil if TLS is not configured).
+	// Once assigned in startTLSWatcher it is never reassigned; closeOnce guards shutdown.
 	watcher *fsnotify.Watcher
+	// closeOnce ensures Close is idempotent and runs the shutdown sequence exactly once.
+	closeOnce sync.Once
+	// wg tracks the watchTLSFiles goroutine so Close can wait for it to exit.
+	wg sync.WaitGroup
 }
 
 // New creates a new HTTP output with the given configuration.
@@ -154,7 +169,7 @@ func (o *Output) Send(ctx context.Context, data []byte) error {
 		}
 
 		if attempt < o.maxSendAttempts {
-			if err := sleepWithContext(ctx, backoffDuration(attempt, o.baseBackoff, o.maxBackoff)); err != nil {
+			if err := sleepFunc(ctx, backoffFunc(attempt, o.baseBackoff, o.maxBackoff)); err != nil {
 				return fmt.Errorf("request canceled while retrying: %w, previous attempt failed with: %w", err, lastErr)
 			}
 		}
@@ -169,19 +184,33 @@ func (o *Output) Name() string {
 }
 
 // Close triggers shutdown of the TLS file watcher goroutine and releases resources.
-// It is safe to call multiple times.
+// It is safe to call multiple times; only the first call performs the shutdown.
+// Close blocks until the background watcher goroutine has exited, so any
+// in-flight TLS reload has completed by the time Close returns.
 func (o *Output) Close() error {
-	if o.watcher == nil {
-		return nil
-	}
-	err := o.watcher.Close()
-	o.watcher = nil
+	var err error
+	o.closeOnce.Do(func() {
+		if o.watcher != nil {
+			err = o.watcher.Close()
+		}
+		o.wg.Wait()
+	})
 	return err
 }
 
 // startTLSWatcher begins watching the directories containing TLS credential files.
 // When files change, the HTTP client is rebuilt with freshly-loaded credentials.
+//
+// If tlsConfig has no file paths set (all of CAFile, CertFile, KeyFile empty),
+// no watcher is created and no goroutine is spawned — there is nothing to
+// watch, so allocating an fsnotify handle and parking a goroutine on empty
+// channels would only waste an FD.
 func (o *Output) startTLSWatcher(ctx context.Context, tlsConfig *configv1alpha1.ClientTLS) error {
+	dirs := tlsDirectories(tlsConfig)
+	if len(dirs) == 0 {
+		return nil
+	}
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
@@ -189,7 +218,6 @@ func (o *Output) startTLSWatcher(ctx context.Context, tlsConfig *configv1alpha1.
 
 	// Watch the parent directories of all configured TLS files.
 	// This handles Kubernetes secret mounts where files are symlinks that get atomically swapped.
-	dirs := tlsDirectories(tlsConfig)
 	for _, dir := range dirs {
 		if err := watcher.Add(dir); err != nil {
 			_ = watcher.Close()
@@ -199,40 +227,71 @@ func (o *Output) startTLSWatcher(ctx context.Context, tlsConfig *configv1alpha1.
 
 	o.watcher = watcher
 
-	go o.watchTLSFiles(ctx, tlsConfig)
+	o.wg.Go(func() {
+		o.watchTLSFiles(ctx, tlsConfig)
+	})
 	return nil
 }
 
 // watchTLSFiles is the event loop for the TLS file watcher.
 func (o *Output) watchTLSFiles(ctx context.Context, tlsConfig *configv1alpha1.ClientTLS) {
-	var debounceTimer *time.Timer
+	watcher := o.watcher
+
+	// debounceTimer is created stopped; debounceC is set to the timer's
+	// channel exactly when the timer is armed and cleared when it fires or is
+	// stopped — this keeps the case a no-op until a reload is actually pending.
+	debounceTimer := time.NewTimer(0)
+	if !debounceTimer.Stop() {
+		<-debounceTimer.C
+	}
+	var debounceC <-chan time.Time
+
+	armDebounce := func() {
+		if debounceC != nil {
+			if !debounceTimer.Stop() {
+				<-debounceTimer.C
+			}
+		}
+		debounceTimer.Reset(o.tlsReloadDebounce)
+		debounceC = debounceTimer.C
+	}
+
+	// Guarantee the timer is stopped on every exit path so it does not linger
+	// past this goroutine's lifetime.
+	defer func() {
+		if debounceC != nil && !debounceTimer.Stop() {
+			<-debounceTimer.C
+		}
+	}()
 
 	for {
 		select {
 		case <-ctx.Done():
-			if debounceTimer != nil {
-				debounceTimer.Stop()
-			}
 			return
 
-		case event, ok := <-o.watcher.Events:
+		case <-debounceC:
+			debounceC = nil
+			o.reloadTLSClient(tlsConfig)
+
+		case event, ok := <-watcher.Events:
 			if !ok {
 				return
 			}
-			// Only react to events that indicate file content changed
-			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Remove) {
+			// Only react to events that indicate file content changed.
+			// Rename is included because Kubernetes secret updates atomically
+			// rename the `..data` symlink into place, which on some platforms
+			// surfaces as a Rename rather than a Create on the target.
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) &&
+				!event.Has(fsnotify.Remove) && !event.Has(fsnotify.Rename) {
 				continue
 			}
 
-			// Debounce: reset timer on each event
-			if debounceTimer != nil {
-				debounceTimer.Stop()
-			}
-			debounceTimer = time.AfterFunc(o.tlsReloadDebounce, func() {
-				o.reloadTLSClient(tlsConfig)
-			})
+			// (Re)arm the debounce on each qualifying event. Coalescing many
+			// rapid events into a single reload happens naturally because the
+			// fire time is pushed forward on every reset.
+			armDebounce()
 
-		case err, ok := <-o.watcher.Errors:
+		case err, ok := <-watcher.Errors:
 			if !ok {
 				return
 			}
@@ -249,7 +308,16 @@ func (o *Output) reloadTLSClient(tlsConfig *configv1alpha1.ClientTLS) {
 		o.logger.Error(err, "Failed to reload TLS credentials, keeping existing client")
 		return
 	}
-	o.client.Store(client)
+
+	old := o.client.Swap(client)
+	if old != nil {
+		// After swapping in the new client, idle keepalive connections on the previous
+		// client's transport are closed explicitly. Otherwise they linger in the old
+		// transport's pool until GC frees the transport, which can be a long time on
+		// mostly-idle servers — over many rotations that leaks file descriptors and
+		// TLS session state, defeating the point of the atomic swap.
+		old.CloseIdleConnections()
+	}
 	o.logger.Info("Reloaded TLS credentials")
 }
 

--- a/internal/output/http/http_test.go
+++ b/internal/output/http/http_test.go
@@ -160,13 +160,13 @@ var _ = Describe("HTTP Output", func() {
 
 		It("should retry on retryable status codes", func() {
 			var attempts int32
-			originalBackoff := httpoutput.BackoffFunc
-			originalSleep := httpoutput.SleepFunc
-			httpoutput.BackoffFunc = func(_ int, _, _ time.Duration) time.Duration { return 0 }
-			httpoutput.SleepFunc = func(_ context.Context, _ time.Duration) error { return nil }
+			originalBackoff := *httpoutput.BackoffFunc
+			originalSleep := *httpoutput.SleepFunc
+			*httpoutput.BackoffFunc = func(_ int, _, _ time.Duration) time.Duration { return 0 }
+			*httpoutput.SleepFunc = func(_ context.Context, _ time.Duration) error { return nil }
 			DeferCleanup(func() {
-				httpoutput.BackoffFunc = originalBackoff
-				httpoutput.SleepFunc = originalSleep
+				*httpoutput.BackoffFunc = originalBackoff
+				*httpoutput.SleepFunc = originalSleep
 			})
 
 			testServer.Close()
@@ -203,6 +203,42 @@ var _ = Describe("HTTP Output", func() {
 			httpOutput, err = httpoutput.New(context.Background(), config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(httpOutput.Close()).To(Succeed())
+		})
+
+		It("should be safe to call multiple times", func() {
+			config := &configv1alpha1.OutputHTTP{
+				URL: testServer.URL,
+			}
+
+			var err error
+			httpOutput, err = httpoutput.New(context.Background(), config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(httpOutput.Close()).To(Succeed())
+			Expect(httpOutput.Close()).To(Succeed())
+		})
+	})
+
+	Describe("WithTLSReloadDebounce", func() {
+		It("should accept a zero duration (no debouncing)", func() {
+			config := &configv1alpha1.OutputHTTP{
+				URL: testServer.URL,
+			}
+
+			var err error
+			httpOutput, err = httpoutput.New(context.Background(), config, httpoutput.WithTLSReloadDebounce(0))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(httpOutput).NotTo(BeNil())
+		})
+
+		It("should reject a negative duration", func() {
+			config := &configv1alpha1.OutputHTTP{
+				URL: testServer.URL,
+			}
+
+			out, err := httpoutput.New(context.Background(), config, httpoutput.WithTLSReloadDebounce(-1*time.Second))
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("TLS reload debounce must be non-negative")))
+			Expect(out).To(BeNil())
 		})
 	})
 })

--- a/internal/output/http/http_test.go
+++ b/internal/output/http/http_test.go
@@ -55,14 +55,14 @@ var _ = Describe("HTTP Output", func() {
 			}
 
 			var err error
-			httpOutput, err = httpoutput.New(config)
+			httpOutput, err = httpoutput.New(context.Background(), config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(httpOutput).NotTo(BeNil())
 			Expect(httpOutput.Name()).To(Equal(testServer.URL))
 		})
 
 		It("should handle nil config", func() {
-			httpOutput, err := httpoutput.New(nil)
+			httpOutput, err := httpoutput.New(context.Background(), nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring("is nil")))
 			Expect(httpOutput).To(BeNil())
@@ -76,7 +76,7 @@ var _ = Describe("HTTP Output", func() {
 				},
 			}
 
-			httpOutput, err := httpoutput.New(config)
+			httpOutput, err := httpoutput.New(context.Background(), config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring("failed to read CA certificate file")))
 			Expect(err).To(MatchError(ContainSubstring("/nonexistent/ca.pem")))
@@ -91,7 +91,7 @@ var _ = Describe("HTTP Output", func() {
 			}
 
 			var err error
-			httpOutput, err = httpoutput.New(config)
+			httpOutput, err = httpoutput.New(context.Background(), config)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -127,7 +127,7 @@ var _ = Describe("HTTP Output", func() {
 				Compression: "gzip",
 			}
 			var err error
-			httpOutput, err = httpoutput.New(config)
+			httpOutput, err = httpoutput.New(context.Background(), config)
 			Expect(err).NotTo(HaveOccurred())
 
 			testData := []byte(`{"events": ["test"]}`)
@@ -184,12 +184,25 @@ var _ = Describe("HTTP Output", func() {
 			}
 
 			var err error
-			httpOutput, err = httpoutput.New(config)
+			httpOutput, err = httpoutput.New(context.Background(), config)
 			Expect(err).NotTo(HaveOccurred())
 
 			testData := []byte(`{"events": ["test"]}`)
 			Expect(httpOutput.Send(context.Background(), testData)).To(Succeed())
 			Expect(atomic.LoadInt32(&attempts)).To(Equal(int32(3)))
+		})
+	})
+
+	Describe("Close", func() {
+		It("should close without error when no TLS watcher is configured", func() {
+			config := &configv1alpha1.OutputHTTP{
+				URL: testServer.URL,
+			}
+
+			var err error
+			httpOutput, err = httpoutput.New(context.Background(), config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(httpOutput.Close()).To(Succeed())
 		})
 	})
 })

--- a/internal/output/http/options.go
+++ b/internal/output/http/options.go
@@ -4,7 +4,11 @@
 
 package http
 
-import "time"
+import (
+	"time"
+
+	"github.com/go-logr/logr"
+)
 
 // Option is a functional option for configuring an HTTP Output.
 type Option func(*Output) error
@@ -32,6 +36,14 @@ func WithBaseBackoff(backoff time.Duration) Option {
 func WithMaxBackoff(backoff time.Duration) Option {
 	return func(o *Output) error {
 		o.maxBackoff = backoff
+		return nil
+	}
+}
+
+// WithLogger sets the logger used for TLS credential reload events.
+func WithLogger(logger logr.Logger) Option {
+	return func(o *Output) error {
+		o.logger = logger
 		return nil
 	}
 }

--- a/internal/output/http/options.go
+++ b/internal/output/http/options.go
@@ -47,3 +47,11 @@ func WithLogger(logger logr.Logger) Option {
 		return nil
 	}
 }
+
+// WithTLSReloadDebounce sets the debounce duration for TLS credential file change events.
+func WithTLSReloadDebounce(d time.Duration) Option {
+	return func(o *Output) error {
+		o.tlsReloadDebounce = d
+		return nil
+	}
+}

--- a/internal/output/http/options.go
+++ b/internal/output/http/options.go
@@ -5,6 +5,7 @@
 package http
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -40,7 +41,7 @@ func WithMaxBackoff(backoff time.Duration) Option {
 	}
 }
 
-// WithLogger sets the logger used for TLS credential reload events.
+// WithLogger sets the logger used by background operations of the HTTP output.
 func WithLogger(logger logr.Logger) Option {
 	return func(o *Output) error {
 		o.logger = logger
@@ -49,8 +50,13 @@ func WithLogger(logger logr.Logger) Option {
 }
 
 // WithTLSReloadDebounce sets the debounce duration for TLS credential file change events.
+// A duration of 0 disables debouncing (events trigger a reload immediately).
+// Negative durations are rejected.
 func WithTLSReloadDebounce(d time.Duration) Option {
 	return func(o *Output) error {
+		if d < 0 {
+			return fmt.Errorf("TLS reload debounce must be non-negative, got %s", d)
+		}
 		o.tlsReloadDebounce = d
 		return nil
 	}

--- a/internal/output/http/tls_reload_test.go
+++ b/internal/output/http/tls_reload_test.go
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	httpoutput "github.com/gardener/auditlog-forwarder/internal/output/http"
+	configv1alpha1 "github.com/gardener/auditlog-forwarder/pkg/apis/config/v1alpha1"
+)
+
+var _ = Describe("TLS Hot Reload", func() {
+	var (
+		tmpDir     string
+		ctx        context.Context
+		cancel     context.CancelFunc
+		httpOutput *httpoutput.Output
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "tls-reload-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel = context.WithCancel(context.Background())
+
+		// Use a very short debounce for tests
+		cleanup := httpoutput.SetTLSReloadDebounceForTest(50 * time.Millisecond)
+		DeferCleanup(cleanup)
+	})
+
+	AfterEach(func() {
+		cancel()
+		if httpOutput != nil {
+			Expect(httpOutput.Close()).To(Succeed())
+		}
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	It("should reload client certificates when files change", func() {
+		// Generate CA
+		caKey, caCert, caPEM := generateCA("Test CA")
+
+		// Generate initial client cert
+		clientCertPEM1, clientKeyPEM1 := generateClientCert(caKey, caCert, "client-1")
+
+		// Write initial certs to files
+		caFile := filepath.Join(tmpDir, "ca.crt")
+		certFile := filepath.Join(tmpDir, "client.crt")
+		keyFile := filepath.Join(tmpDir, "client.key")
+
+		Expect(os.WriteFile(caFile, caPEM, 0600)).To(Succeed())
+		Expect(os.WriteFile(certFile, clientCertPEM1, 0600)).To(Succeed())
+		Expect(os.WriteFile(keyFile, clientKeyPEM1, 0600)).To(Succeed())
+
+		// Create a TLS test server that requires client certs and captures the subject
+		caCertPool := x509.NewCertPool()
+		caCertPool.AddCert(caCert)
+
+		var receivedSubject string
+		testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+				receivedSubject = r.TLS.PeerCertificates[0].Subject.CommonName
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		testServer.TLS = &tls.Config{
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  caCertPool,
+			MinVersion: tls.VersionTLS12,
+		}
+		testServer.StartTLS()
+		defer testServer.Close()
+
+		// Extract server's CA for the client to trust
+		serverCAPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: testServer.TLS.Certificates[0].Certificate[0],
+		})
+		serverCAFile := filepath.Join(tmpDir, "server-ca.crt")
+		Expect(os.WriteFile(serverCAFile, serverCAPEM, 0600)).To(Succeed())
+
+		// Create output with TLS config
+		config := &configv1alpha1.OutputHTTP{
+			URL: testServer.URL,
+			TLS: &configv1alpha1.ClientTLS{
+				CAFile:   serverCAFile,
+				CertFile: certFile,
+				KeyFile:  keyFile,
+			},
+		}
+
+		var err error
+		httpOutput, err = httpoutput.New(ctx, config)
+		Expect(err).NotTo(HaveOccurred())
+
+		// First request should use client-1 cert
+		Expect(httpOutput.Send(context.Background(), []byte(`{"test": 1}`))).To(Succeed())
+		Expect(receivedSubject).To(Equal("client-1"))
+
+		// Generate a new client cert with a different CN
+		clientCertPEM2, clientKeyPEM2 := generateClientCert(caKey, caCert, "client-2")
+
+		// Write new certs to the same files
+		Expect(os.WriteFile(certFile, clientCertPEM2, 0600)).To(Succeed())
+		Expect(os.WriteFile(keyFile, clientKeyPEM2, 0600)).To(Succeed())
+
+		// Wait for the watcher to pick up the change (debounce + processing)
+		Eventually(func() string {
+			_ = httpOutput.Send(context.Background(), []byte(`{"test": 2}`))
+			return receivedSubject
+		}, 2*time.Second, 100*time.Millisecond).Should(Equal("client-2"))
+	})
+
+	It("should reload CA certificate when file changes", func() {
+		// Generate two different CAs
+		caKey1, caCert1, caPEM1 := generateCA("Test CA 1")
+		caKey2, caCert2, caPEM2 := generateCA("Test CA 2")
+
+		// Generate server certs signed by each CA
+		serverCert1 := generateServerCert(caKey1, caCert1, "127.0.0.1")
+		serverCert2 := generateServerCert(caKey2, caCert2, "127.0.0.1")
+
+		// Start with CA 1 as the trusted CA on the client side
+		caFile := filepath.Join(tmpDir, "ca.crt")
+		Expect(os.WriteFile(caFile, caPEM1, 0600)).To(Succeed())
+
+		// Create a test server using cert signed by CA 1
+		testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		testServer.TLS = &tls.Config{
+			Certificates: []tls.Certificate{serverCert1},
+			MinVersion:   tls.VersionTLS12,
+		}
+		testServer.StartTLS()
+		defer testServer.Close()
+
+		// Create output trusting CA 1
+		config := &configv1alpha1.OutputHTTP{
+			URL: testServer.URL,
+			TLS: &configv1alpha1.ClientTLS{
+				CAFile: caFile,
+			},
+		}
+
+		var err error
+		httpOutput, err = httpoutput.New(ctx, config)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Request should succeed (server cert signed by CA 1, client trusts CA 1)
+		Expect(httpOutput.Send(context.Background(), []byte(`{"test": 1}`))).To(Succeed())
+
+		// Now switch the server to use a cert signed by CA 2
+		testServer.Close()
+
+		testServer2 := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		testServer2.TLS = &tls.Config{
+			Certificates: []tls.Certificate{serverCert2},
+			MinVersion:   tls.VersionTLS12,
+		}
+		testServer2.Listener, err = net.Listen("tcp", testServer.Listener.Addr().String())
+		Expect(err).NotTo(HaveOccurred())
+		testServer2.StartTLS()
+		defer testServer2.Close()
+
+		// Request should fail (server cert signed by CA 2, client still trusts CA 1)
+		err = httpOutput.Send(context.Background(), []byte(`{"test": 2}`))
+		Expect(err).To(HaveOccurred())
+
+		// Update the CA file to trust CA 2
+		Expect(os.WriteFile(caFile, caPEM2, 0600)).To(Succeed())
+
+		// Wait for the watcher to reload, then verify requests succeed
+		Eventually(func() error {
+			return httpOutput.Send(context.Background(), []byte(`{"test": 3}`))
+		}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("should keep the old client when new cert files are invalid", func() {
+		// Generate CA and valid client cert
+		caKey, caCert, caPEM := generateCA("Test CA")
+		clientCertPEM, clientKeyPEM := generateClientCert(caKey, caCert, "valid-client")
+
+		caFile := filepath.Join(tmpDir, "ca.crt")
+		certFile := filepath.Join(tmpDir, "client.crt")
+		keyFile := filepath.Join(tmpDir, "client.key")
+
+		Expect(os.WriteFile(caFile, caPEM, 0600)).To(Succeed())
+		Expect(os.WriteFile(certFile, clientCertPEM, 0600)).To(Succeed())
+		Expect(os.WriteFile(keyFile, clientKeyPEM, 0600)).To(Succeed())
+
+		// Create a TLS test server
+		caCertPool := x509.NewCertPool()
+		caCertPool.AddCert(caCert)
+
+		testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		testServer.TLS = &tls.Config{
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  caCertPool,
+			MinVersion: tls.VersionTLS12,
+		}
+		testServer.StartTLS()
+		defer testServer.Close()
+
+		// Extract server CA
+		serverCAPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: testServer.TLS.Certificates[0].Certificate[0],
+		})
+		serverCAFile := filepath.Join(tmpDir, "server-ca.crt")
+		Expect(os.WriteFile(serverCAFile, serverCAPEM, 0600)).To(Succeed())
+
+		config := &configv1alpha1.OutputHTTP{
+			URL: testServer.URL,
+			TLS: &configv1alpha1.ClientTLS{
+				CAFile:   serverCAFile,
+				CertFile: certFile,
+				KeyFile:  keyFile,
+			},
+		}
+
+		var err error
+		httpOutput, err = httpoutput.New(ctx, config)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Initial request succeeds
+		Expect(httpOutput.Send(context.Background(), []byte(`{"test": 1}`))).To(Succeed())
+
+		// Write invalid cert data
+		Expect(os.WriteFile(certFile, []byte("not a valid cert"), 0600)).To(Succeed())
+
+		// Wait for debounce to fire
+		time.Sleep(200 * time.Millisecond)
+
+		// Requests should still succeed (old client kept on reload failure)
+		Expect(httpOutput.Send(context.Background(), []byte(`{"test": 2}`))).To(Succeed())
+	})
+})
+
+// generateCA creates a self-signed CA certificate.
+func generateCA(cn string) (*ecdsa.PrivateKey, *x509.Certificate, []byte) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	Expect(err).NotTo(HaveOccurred())
+
+	cert, err := x509.ParseCertificate(certDER)
+	Expect(err).NotTo(HaveOccurred())
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	return key, cert, certPEM
+}
+
+// generateClientCert creates a client certificate signed by the given CA.
+func generateClientCert(caKey *ecdsa.PrivateKey, caCert *x509.Certificate, cn string) (certPEM, keyPEM []byte) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	Expect(err).NotTo(HaveOccurred())
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM
+}
+
+// generateServerCert creates a server certificate signed by the given CA for the specified IP.
+func generateServerCert(caKey *ecdsa.PrivateKey, caCert *x509.Certificate, ip string) tls.Certificate {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: ip},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP(ip)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	Expect(err).NotTo(HaveOccurred())
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	Expect(err).NotTo(HaveOccurred())
+
+	return tlsCert
+}

--- a/internal/output/http/tls_reload_test.go
+++ b/internal/output/http/tls_reload_test.go
@@ -42,10 +42,6 @@ var _ = Describe("TLS Hot Reload", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx, cancel = context.WithCancel(context.Background())
-
-		// Use a very short debounce for tests
-		cleanup := httpoutput.SetTLSReloadDebounceForTest(50 * time.Millisecond)
-		DeferCleanup(cleanup)
 	})
 
 	AfterEach(func() {
@@ -99,7 +95,7 @@ var _ = Describe("TLS Hot Reload", func() {
 		serverCAFile := filepath.Join(tmpDir, "server-ca.crt")
 		Expect(os.WriteFile(serverCAFile, serverCAPEM, 0600)).To(Succeed())
 
-		// Create output with TLS config
+		// Create output with TLS config and short debounce for testing
 		config := &configv1alpha1.OutputHTTP{
 			URL: testServer.URL,
 			TLS: &configv1alpha1.ClientTLS{
@@ -110,7 +106,7 @@ var _ = Describe("TLS Hot Reload", func() {
 		}
 
 		var err error
-		httpOutput, err = httpoutput.New(ctx, config)
+		httpOutput, err = httpoutput.New(ctx, config, httpoutput.WithTLSReloadDebounce(50*time.Millisecond))
 		Expect(err).NotTo(HaveOccurred())
 
 		// First request should use client-1 cert
@@ -155,7 +151,7 @@ var _ = Describe("TLS Hot Reload", func() {
 		testServer.StartTLS()
 		defer testServer.Close()
 
-		// Create output trusting CA 1
+		// Create output trusting CA 1 with short debounce for testing
 		config := &configv1alpha1.OutputHTTP{
 			URL: testServer.URL,
 			TLS: &configv1alpha1.ClientTLS{
@@ -164,7 +160,7 @@ var _ = Describe("TLS Hot Reload", func() {
 		}
 
 		var err error
-		httpOutput, err = httpoutput.New(ctx, config)
+		httpOutput, err = httpoutput.New(ctx, config, httpoutput.WithTLSReloadDebounce(50*time.Millisecond))
 		Expect(err).NotTo(HaveOccurred())
 
 		// Request should succeed (server cert signed by CA 1, client trusts CA 1)
@@ -244,7 +240,7 @@ var _ = Describe("TLS Hot Reload", func() {
 		}
 
 		var err error
-		httpOutput, err = httpoutput.New(ctx, config)
+		httpOutput, err = httpoutput.New(ctx, config, httpoutput.WithTLSReloadDebounce(50*time.Millisecond))
 		Expect(err).NotTo(HaveOccurred())
 
 		// Initial request succeeds
@@ -253,11 +249,10 @@ var _ = Describe("TLS Hot Reload", func() {
 		// Write invalid cert data
 		Expect(os.WriteFile(certFile, []byte("not a valid cert"), 0600)).To(Succeed())
 
-		// Wait for debounce to fire
-		time.Sleep(200 * time.Millisecond)
-
-		// Requests should still succeed (old client kept on reload failure)
-		Expect(httpOutput.Send(context.Background(), []byte(`{"test": 2}`))).To(Succeed())
+		// Verify requests keep succeeding (old client kept on reload failure)
+		Consistently(func() error {
+			return httpOutput.Send(context.Background(), []byte(`{"test": 2}`))
+		}, 500*time.Millisecond, 50*time.Millisecond).Should(Succeed())
 	})
 })
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -16,4 +16,7 @@ type Output interface {
 
 	// Name returns a human-readable name/identifier for this output.
 	Name() string
+
+	// Close releases resources associated with this output.
+	Close() error
 }


### PR DESCRIPTION
## What

Add automatic reload of TLS client credentials (client cert/key and CA) for HTTP outputs using fsnotify. When certificate files change on disk, the HTTP client is rebuilt with freshly-loaded credentials and atomically swapped in, enabling certificate rotation without pod restarts.

## Why

In Kubernetes, secrets are rotated in-place via atomic symlink swap. Previously, a pod restart was required to pick up new TLS credentials. This is problematic for long-running forwarder instances where certificate rotation should be transparent.

## How

- Each HTTP output with TLS configured starts an fsnotify watcher on the parent directories of its cert files
- Filesystem events are debounced (500ms default, configurable via `WithTLSReloadDebounce`) to coalesce rapid Kubernetes secret update events
- On change, `createHTTPClient` rebuilds the client with fresh certs and stores it via `atomic.Pointer[http.Client]`
- `Send()` reads the current client atomically - no locking on the hot path
- On reload failure, the existing client is preserved and the error is logged
- `Close()` on the Output interface allows clean watcher shutdown

## Key design decisions

- **Watch directories, not files**: handles Kubernetes symlink swaps and file replacements reliably
- **`atomic.Pointer[http.Client]`**: lock-free reads in the send path
- **Graceful degradation**: reload errors are logged but never crash the process
- **No config changes needed**: the existing `ClientTLS` fields are sufficient

## Testing

- Full TLS reload tests with generated certificates verifying:
  - Client cert rotation is picked up
  - CA rotation is picked up
  - Invalid cert files do not break existing connections
- All existing tests updated and passing
- `make verify` passes (lint, vet, tests, gosec)


```feature operator
Implement hot-reload of TLS client credentials for HTTP outputs.
```